### PR TITLE
Minor change for invalid auth_token cookie

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -32,6 +32,8 @@ class ApplicationController < ActionController::Base
     if current_user.nil?
       unless cookies[:auth_token].blank?
         user = User.find_by_remember_token(cookies[:auth_token])
+      end
+      if user 
         user.refresh_remember_token
         session[:user_id] = user.id
         cookies[:auth_token] = user.remember_token


### PR DESCRIPTION
Hi Mischa,

I've made a minor change to the code, if an auth_token cookie happens to be invalid
no user will be found and the application will be in an error state.

This change prevents that, if no user is found the session will be reset again.

Greetings,
Rob Halff
